### PR TITLE
Batched prediction

### DIFF
--- a/example/run_examples.py
+++ b/example/run_examples.py
@@ -1,7 +1,6 @@
-from NCR_Classifier import predict
+from MOFClassifier.CLscore import predict
 import glob
 import csv
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from tqdm import tqdm
 
 input_pattern = "/path/to/folder/*.cif"
@@ -22,26 +21,21 @@ with open(score_csv, "w", newline="") as f:
 
 open(fail_txt, "w").close()
 
+results = predict(files)
+
 scores_f = open(scores_csv, "a", newline="")
 score_f  = open(score_csv,  "a", newline="")
 fail_f   = open(fail_txt,   "a")
 
 scores_writer = csv.writer(scores_f)
-score_writer  = csv.writer(score_f)
+score_writer = csv.writer(score_f)
 
-with ProcessPoolExecutor(max_workers=10) as executor:
-    futures = {executor.submit(predict, fn): fn for fn in files}
-    for future in tqdm(as_completed(futures), total=len(futures), desc="Predicting"):
-        fn = futures[future]
-        try:
-            cifid, CLscores, CLscore = future.result()
-            scores_writer.writerow([cifid] + CLscores)
-            scores_f.flush()
-            score_writer.writerow([cifid, CLscore])
-            score_f.flush()
-        except Exception:
-            fail_f.write(fn + "\n")
-            fail_f.flush()
+for result in tqdm(results, total=len(results), desc="Predicting"):
+    cifid, CLscores, CLscore = result
+    scores_writer.writerow([cifid] + CLscores)
+    scores_f.flush()
+    score_writer.writerow([cifid, CLscore])
+    score_f.flush()
 
 scores_f.close()
 score_f.close()


### PR DESCRIPTION
## Issue description
The current prediction script and example rely on process-level parallelism, which does not exploit the GPU-level parallelism from torch. 

This PR introduces batched predictions, leveraging torch's batching. 

### The introduced changes are:

1. `CLscore.predict` now takes a list of `root_cif`s instead of a single filename. Consequently, it returns a list of tuples as output. There might be better ways to handle this, but it follows the logic of the existing example.
2. The example script no longer requires process-level parallelism, but passes the list of files directly to the `predict` method.

### The effects are:
- 10x speedup in GPU evaluation (345 structures, 10 CPU cores, 1 H100 GPU) -> Walltime reduced from 11 minutes to 1 minute.
- Same CPU speed, but significantly reduced CPU utilization (356 structures, 10 CPU cores) -> 11 minutes, CPU efficiency as reported by SLURM from 89.36% to 7.13%.
- No change in the predictions beyond noise levels: Maximum difference between CLscores (100 models, 345 structures) is 1.1e-6


